### PR TITLE
Specify that the lifecycle needs to be bound first

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The latest version of BndrsntchTimer is  [![](https://jitpack.io/v/iamporus/Bndr
 ### Java
 ```java
 final BndrsntchTimer bndrsntchTimer = findViewById( R.id.timer );
+getLifecycle().addObserver( bndrsntchTimer.getLifecycleObserver() );
 
 //set progress color
 bndrsntchTimer.setProgressColorInt( android.R.color.holo_blue_bright );


### PR DESCRIPTION
Fragment/Activity hosting the control needs to add the observer from the timer.

This fixes #1 